### PR TITLE
chore(gitignore): add node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 # Documentation here: https://yarnpkg.com/features/zero-installs
 # !.yarn/cache
 .pnp.*
+node_modules/


### PR DESCRIPTION
The `node_modules` directory is setup when the `yarn.lock` is set up from scratch. This directory should not be checked in to version control.